### PR TITLE
Fix footstep color for ROLE_NONE

### DIFF
--- a/gamemodes/terrortown/entities/weapons/weapon_ttt2_lens.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_ttt2_lens.lua
@@ -422,7 +422,7 @@ else
 		if ply:GetSubRole() ~= ROLE_NONE then
 			tbl.col = ply:GetRoleColor()
 		else
-			tbl.col = Color(80, 173, 59, 255)
+			tbl.col = INNOCENT.color
 		end
 		tbl.bloody = bloody
 

--- a/gamemodes/terrortown/entities/weapons/weapon_ttt2_lens.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_ttt2_lens.lua
@@ -422,7 +422,7 @@ else
 		if ply:GetSubRole() ~= ROLE_NONE then
 			tbl.col = ply:GetRoleColor()
 		else
-			tbl.col = INNOCENT.color
+			tbl.col = roles.INNOCENT.color
 		end
 		tbl.bloody = bloody
 

--- a/gamemodes/terrortown/entities/weapons/weapon_ttt2_lens.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_ttt2_lens.lua
@@ -419,7 +419,11 @@ else
 		tbl.curtime = CurTime()
 		tbl.angle = ang.y
 		tbl.normal = tr.HitNormal
-		tbl.col = ply:GetRoleColor()
+		if ply:GetSubRole() ~= ROLE_NONE then
+			tbl.col = ply:GetRoleColor()
+		else
+			tbl.col = Color(80, 173, 59, 255)
+		end
 		tbl.bloody = bloody
 
 		hook.Run("TTT2SnifferModifyFootstep", ply, tbl)


### PR DESCRIPTION
Fixed the footsteps appearing as Gray for non-public role players. Now appears as Innocent green unless their role is known to the Sniffer as something other than ROLE_NONE.