### PR TITLE
Fix: Fixed Lens error when dying | Added PreDrop function

### DIFF
--- a/gamemodes/terrortown/entities/weapons/weapon_ttt2_lens.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_ttt2_lens.lua
@@ -106,7 +106,7 @@ local plymeta = FindMetaTable("Player")
 if not plymeta then return end
 
 function plymeta:CanSeeFootsteps()
-	return self:Alive() and self:IsTerror() and self:GetActiveWeapon() and self:GetActiveWeapon():GetClass() == "weapon_ttt2_lens" and self:GetActiveWeapon():GetIronsights()
+	return self:Alive() and self:IsTerror() and IsValid(self:GetActiveWeapon()) and self:GetActiveWeapon():GetClass() == "weapon_ttt2_lens" and self:GetActiveWeapon():GetIronsights()
 end
 
 function plymeta:CanSeeFootblood(target)
@@ -417,6 +417,12 @@ function SWEP:SecondaryAttack()
 	self:SyncIrons(irons)
 
 	return r
+end
+
+function SWEP:PreDrop()
+	self:SetIronsights(false)
+	self:SetZoom(false)
+	self:SyncIrons(false)
 end
 
 if CLIENT then


### PR DESCRIPTION
It looks like we need an IsValid check here.. For somereason self:GetActiveWeapon passes in the first frame of death, but IsValid works without issues..

Also added the PreDrop function to disable the ironsight state.

Fixes: https://github.com/TTT-2/ttt2-role_snif/issues/12